### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,6 +23,13 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def update
+    item = Item.find(params[:id])
+    item.update(item_params)
+      redirect_to item_path
+  end
+
+
   # def destroy
     # @item = Item.find(params[:id])
   # end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :selectitem, only: [:show, :edit, :update ]
 
   # ログインしていなければ指定ページにとべない
   def index
@@ -20,22 +21,22 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
+    redirect_to root_path if current_user.id != @item.user_id
   end
 
   def update
-    item = Item.find(params[:id])
-    item.update(item_params)
+    if @item.update(item_params)
       redirect_to item_path
+    else
+      render :edit
+    end
   end
-
 
   # def destroy
     # @item = Item.find(params[:id])
   # end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   private
@@ -43,4 +44,9 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:name, :text, :image, :value, :condition_id, :category_id, :postage_id, :prefecture_id, :shipment_day_id).merge(user_id: current_user.id)
   end
+
+  def selectitem
+    @item = Item.find(params[:id])
+  end
 end
+

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,10 +19,10 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def edit
-    # @item = Item.find(params[:id])
-  # end
-# 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
   # def destroy
     # @item = Item.find(params[:id])
   # end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :selectitem, only: [:show, :edit, :update ]
+  before_action :selectitem, only: [:show, :edit, :update]
 
   # ログインしていなければ指定ページにとべない
   def index
@@ -33,7 +33,7 @@ class ItemsController < ApplicationController
   end
 
   # def destroy
-    # @item = Item.find(params[:id])
+  # @item = Item.find(params[:id])
   # end
 
   def show
@@ -42,11 +42,11 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :text, :image, :value, :condition_id, :category_id, :postage_id, :prefecture_id, :shipment_day_id).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :text, :image, :value, :condition_id, :category_id, :postage_id, :prefecture_id,
+                                 :shipment_day_id).merge(user_id: current_user.id)
   end
 
   def selectitem
     @item = Item.find(params[:id])
   end
 end
-

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,7 +7,7 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, url: item_path, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%# render 'shared/error_messages', model: f.object %>
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :text, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:postage_id, Postage.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipment_day_id, ShipmentDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :value, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +141,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', "/", class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -10,7 +10,7 @@ app/assets/stylesheets/items/new.css %>
     <%= form_with model: @item, url: item_path, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
@@ -141,7 +141,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "/", class:"back-btn" %>
+      <%=link_to 'もどる', root_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,8 +30,7 @@
 
     <%if user_signed_in? %>
      <% if current_user.id == @item.user_id %>
-       <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %> 
-         <%# edit_item_path(@item.id) %>
+       <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %> 
         <p class='or-text'>or</p>
        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <%# item_path(@item.id) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :show, :new, :create, :edit]
+  resources :items, only: [:index, :show, :new, :create, :edit, :update]
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  root to: 'items#index' #show.html.erbに繋げる
-  resources :items, only: [:index, :new, :create, :show]
+  root to: 'items#index'
+  resources :items, only: [:index, :show, :new, :create, :edit]
 
 end


### PR DESCRIPTION
# what
　商品情報編集機能の実装
　　editアクションのルーティング設定
　　編集ボタンを実装
　　editアクションの定義
　　編集画面のビューの作成
　　updateアクションのルーティング設定
　　updateアクションの定義

# why
　商品の詳細ページから編集ページへ遷移
　商品編集後、商品の詳細ページに遷移

商品情報の変更
https://i.gyazo.com/1829d2fba3fdd96e7e62ced4e7b218f0.mp4
出品者以外の画面遷移
https://i.gyazo.com/4bb50b8d68473c7a93329080f076fa17.mp4
編集なしに画像がなしにならない
https://i.gyazo.com/4b7e25b6e08469eb7c819f7deeffb075.mp4